### PR TITLE
Include all bootstrap classes in browser

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -3,14 +3,10 @@
 require_once('lib/TerribleAutoloader.php');
 TerribleAutoloader::Init();
 
-$bootstrap_classes = ExamplesData::GetClassesWithExamples();
+$bootstrap_classes = ExamplesData::GetBootstrapClasses();
 $class = array_key_exists('classname', $_GET)
-  ? $_GET['classname'] : $bootstrap_classes->keys()->at(0);
-$examples = Vector { };
-if ($bootstrap_classes->containsKey($class)) {
-  $examples = $bootstrap_classes[$class];
-}
-$bootstrap_classes = $bootstrap_classes->keys();
+  ? $_GET['classname'] : $bootstrap_classes->at(0);
+$examples = ExamplesData::GetExamples($class);
 sort($bootstrap_classes);
 
 function prettify_class(string $mangled): string {

--- a/example/lib/ExamplesData.php
+++ b/example/lib/ExamplesData.php
@@ -1,11 +1,15 @@
 <?hh
 
 class ExamplesData {
-  private static function GetBootstrapClasses(): Vector<string> {
+  public static function GetBootstrapClasses(): Vector<string> {
     $all_classes = Vector::fromArray(
       array_keys(TerribleAutoloader::GetClassMap()
     ));
-    return $all_classes->filter($x ==> strpos($x, 'xhp_bootstrap__') === 0);
+    return $all_classes->filter(
+      $x ==>
+        strpos($x, 'xhp_bootstrap__') === 0
+        && !(new ReflectionClass($x))->isAbstract()
+    );
   }
 
   public static function GetExamples(string $class): Vector<ReflectionMethod> {
@@ -14,6 +18,11 @@ class ExamplesData {
     }
 
     $rc = new ReflectionClass($class);
+    if ((list($example_class) = $rc->getAttribute('ExamplesInClass'))) {
+      $mangled =
+        'xhp_'.str_replace([':', '-'], ['__', '_'], substr($example_class, 1));
+      $rc = new ReflectionClass($mangled);
+    }
     $candidates = $rc->getMethods(
       ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC
     );

--- a/lib/xhp-bootstrap/dropdown/divider.php
+++ b/lib/xhp-bootstrap/dropdown/divider.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:dropdown')>>
 final class :bootstrap:dropdown:divider extends :bootstrap:base {
   protected function render(): :xhp {
     return

--- a/lib/xhp-bootstrap/dropdown/item.php
+++ b/lib/xhp-bootstrap/dropdown/item.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:dropdown')>>
 final class :bootstrap:dropdown:item extends :bootstrap:base {
   attribute :a, :bootstrap:base;
 

--- a/lib/xhp-bootstrap/dropdown/menu.php
+++ b/lib/xhp-bootstrap/dropdown/menu.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:dropdown')>>
 final class :bootstrap:dropdown:menu extends :bootstrap:base {
   children ((:bootstrap:dropdown:item|:bootstrap:dropdown:divider)*);
 

--- a/lib/xhp-bootstrap/list-group/list-group-item.php
+++ b/lib/xhp-bootstrap/list-group/list-group-item.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:list-group')>>
 final class :bootstrap:list-group-item extends :bootstrap:base {
   attribute
     enum {

--- a/lib/xhp-bootstrap/navbar/brand.php
+++ b/lib/xhp-bootstrap/navbar/brand.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:navbar')>>
 class :bootstrap:navbar:brand extends :bootstrap:base {
   attribute
     Stringish href @required,

--- a/lib/xhp-bootstrap/navbar/navbar-link.php
+++ b/lib/xhp-bootstrap/navbar/navbar-link.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:navbar')>>
 class :bootstrap:navbar:link extends :bootstrap:base {
   attribute
     bool active = false,

--- a/lib/xhp-bootstrap/panels/panel-section.php
+++ b/lib/xhp-bootstrap/panels/panel-section.php
@@ -1,5 +1,6 @@
 <?hh
 
+<<ExamplesInClass(':bootstrap:panel')>>
 abstract class :bootstrap:panel:section extends :bootstrap:base {
   attribute
     :bootstrap:base;
@@ -16,18 +17,21 @@ abstract class :bootstrap:panel:section extends :bootstrap:base {
   }
 }
 
+<<ExamplesInClass(':bootstrap:panel')>>
 class :bootstrap:panel:heading extends :bootstrap:panel:section {
   protected function getSectionStyle(): string {
     return 'panel-heading';
   }
 }
 
+<<ExamplesInClass(':bootstrap:panel')>>
 class :bootstrap:panel:body extends :bootstrap:panel:section {
   protected function getSectionStyle(): string {
     return 'panel-body';
   }
 }
 
+<<ExamplesInClass(':bootstrap:panel')>>
 class :bootstrap:panel:footer extends :bootstrap:panel:section {
   protected function getSectionStyle(): string {
     return 'panel-footer';


### PR DESCRIPTION
This makes sense now that attributes are listed. Also, allow
delegating examples - eg :bootstrap:navbar:brand shows the examples from
:bootstrap:navbar
