### PR TITLE
Fix hyperlinks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Getting Started
 
 #### Step 1: Include Bootstrap Prerequisites
 
-Bootstrap's JavaScript components require [jQuery](http://jquery.com/download
-/) to be included, so either grab the [downloadable version](http://jquery.co
-m/download/) and reference it, or [use a CDN](http://jquery.com/download/#usi
-ng-jquery-with-a-cdn) and include it in the head of your XHP document:
+Bootstrap's JavaScript components require [jQuery](http://jquery.com/download/)
+to be included, so either grab the [downloadable version](http://jquery.com/download/)
+and reference it, or [use a CDN](http://jquery.com/download/#using-jquery-with-a-cdn)
+and include it in the head of your XHP document:
 
 ````
 <head>
@@ -35,9 +35,9 @@ ng-jquery-with-a-cdn) and include it in the head of your XHP document:
 
 #### Step 2: Include Bootstrap Source
 
-Grab the latest [Bootstrap package](http://getbootstrap.com/getting-started/#
-download) and reference it, or use their [CDN links](http://getbootstrap.com/
-getting-started/#download) and include them in the head of your XHP document:
+Grab the latest [Bootstrap package](http://getbootstrap.com/getting-started/#download)
+and reference it, or use their [CDN links](http://getbootstrap.com/getting-started/#download)
+and include them in the head of your XHP document:
 
 ````
 <head>
@@ -59,8 +59,7 @@ getting-started/#download) and include them in the head of your XHP document:
 #### Step 3: Enable Composer Autoloading
 
 If you haven't already, include the following in your XHP to enable
-[autoloading from Composer](https://getcomposer.org/doc/01-basic-usage.
-md#autoloading):
+[autoloading from Composer](https://getcomposer.org/doc/01-basic-usage.md#autoloading):
 
 ````
   require_once('vendor/autoload.php');


### PR DESCRIPTION
GitHub Markdown doesn't like when you try to split link URLs across lines
